### PR TITLE
add optional border layer

### DIFF
--- a/index.html
+++ b/index.html
@@ -288,6 +288,21 @@ Promise.all([
   Object.values(dataLayers).forEach(dataLayer => dataLayer.addData(grid));
 });
 
+borderLayer=L.geoJSON(undefined,{
+    style:{
+        color: "#000000",
+        fillOpacity: 0,
+        opacity:0.3,
+        weight:1
+    }
+}).addTo(map);
+
+fetch('./grid_20000_id.geojson')
+        .then(data => data.json())
+        .then(data=>{
+            borderLayer.addData(data);   
+});
+
 L.Control.Legend = L.Control.extend({
   onAdd: function(map) {
     const container = L.DomUtil.create('div');
@@ -355,7 +370,7 @@ L.control.legend = function(opts) {
 }
 L.control.legend({ position: 'bottomleft' }).addTo(map);
 
-L.control.layers(dataLayers, {}, {
+L.control.layers(dataLayers, {"Grid Borders":borderLayer}, {
   position: 'bottomleft',
   collapsed: false
 }).addTo(map);

--- a/index.html
+++ b/index.html
@@ -263,12 +263,22 @@ Object.keys(eventTypes).forEach(type => {
   });
 });
 
+const borderLayer = L.geoJSON(undefined, {
+    style: {
+        color: "#000000",
+        fillOpacity: 0,
+        opacity:0.3,
+        weight:1
+    }
+});
+
 Promise.all([
   fetch('./grid_20000_id.geojson').then(data => data.json()),
   fetch('./event_weights_by_cell.csv').then(data => data.text()),
   fetch('./globalNone.geojson').then(data => data.json()),
 ]).then(data => {
   const grid = data[0];
+            borderLayer.addData(data);   
 	const global = data[2];
 	addGlobalNone(global);
   const valuesMap = {};
@@ -286,21 +296,6 @@ Promise.all([
     f.properties['events'] = valuesMap[f.properties.id] || {};
   });
   Object.values(dataLayers).forEach(dataLayer => dataLayer.addData(grid));
-});
-
-borderLayer=L.geoJSON(undefined,{
-    style:{
-        color: "#000000",
-        fillOpacity: 0,
-        opacity:0.3,
-        weight:1
-    }
-}).addTo(map);
-
-fetch('./grid_20000_id.geojson')
-        .then(data => data.json())
-        .then(data=>{
-            borderLayer.addData(data);   
 });
 
 L.Control.Legend = L.Control.extend({
@@ -370,7 +365,7 @@ L.control.legend = function(opts) {
 }
 L.control.legend({ position: 'bottomleft' }).addTo(map);
 
-L.control.layers(dataLayers, {"Grid Borders":borderLayer}, {
+L.control.layers(dataLayers, {}, {
   position: 'bottomleft',
   collapsed: false
 }).addTo(map);
@@ -378,7 +373,7 @@ L.control.layers(dataLayers, {"Grid Borders":borderLayer}, {
 L.control.layers({
   'OpenStreetMap Carto': osmBaseLayer,
   'OSM node density': nodeDensityBaseLayer
-}, {}, {
+}, { "show grid borders" : borderLayer }, {
   position: 'bottomleft',
   collapsed: true
 }).addTo(map);


### PR DESCRIPTION
this pr adds another overlay layer that depicts grid borders. It is useful to distinguish between areas where no event occur and areas where only a single grid cell covers large areas.